### PR TITLE
[v4.0.0+1.20] organized entrypoints

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
 	loader_version=0.15.11
 
 # Mod Properties
-	mod_version=3.1.4+1.20
+	mod_version=4.0.0+1.20
 	mod_id=reinfcore
 	maven_group=atonkish.reinfcore
 	archives_base_name=reinforced-core

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.parallel=true
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.20.6
-	yarn_mappings=1.20.6+build.1
-	loader_version=0.15.10
+	yarn_mappings=1.20.6+build.3
+	loader_version=0.15.11
 
 # Mod Properties
 	mod_version=3.1.4+1.20
@@ -15,6 +15,6 @@ org.gradle.parallel=true
 	archives_base_name=reinforced-core
 
 # Dependencies
-	fabric_version=0.97.8+1.20.6
+	fabric_version=0.100.0+1.20.6
 	mod_menu_version=10.0.0-beta.1
 	cloth_config_version=14.0.126

--- a/src/client/java/atonkish/reinfcore/ReinforcedCoreClientMod.java
+++ b/src/client/java/atonkish/reinfcore/ReinforcedCoreClientMod.java
@@ -11,9 +11,10 @@ import atonkish.reinfcore.api.ReinforcedCoreClientModInitializer;
 public class ReinforcedCoreClientMod implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-		// entrypoint: "reinfcoreclient"
+		// entrypoint: "reinfcore-client"
 		FabricLoader.getInstance()
-				.getEntrypoints(ReinforcedCoreMod.MOD_ID + "client", ReinforcedCoreClientModInitializer.class)
+				.getEntrypoints(String.format("%s-client", ReinforcedCoreMod.MOD_ID),
+						ReinforcedCoreClientModInitializer.class)
 				.forEach(ReinforcedCoreClientModInitializer::onInitializeReinforcedCoreClient);
 	}
 }

--- a/src/main/java/atonkish/reinfcore/ReinforcedCoreMod.java
+++ b/src/main/java/atonkish/reinfcore/ReinforcedCoreMod.java
@@ -1,13 +1,20 @@
 package atonkish.reinfcore;
 
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.loader.api.FabricLoader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
+
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.entrypoint.EntrypointContainer;
+
+import net.minecraft.test.TestFunctions;
 
 import atonkish.reinfcore.api.ReinforcedCoreModInitializer;
 import atonkish.reinfcore.item.ModItemGroups;
@@ -16,6 +23,7 @@ public class ReinforcedCoreMod implements ModInitializer {
 	public static final String MOD_ID = "reinfcore";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 	public static ReinforcedCoreConfig CONFIG;
+	private static final Map<Class<?>, String> GAME_TEST_IDS = new HashMap<>();
 
 	@Override
 	public void onInitialize() {
@@ -30,5 +38,28 @@ public class ReinforcedCoreMod implements ModInitializer {
 		FabricLoader.getInstance()
 				.getEntrypoints(MOD_ID, ReinforcedCoreModInitializer.class)
 				.forEach(ReinforcedCoreModInitializer::onInitializeReinforcedCore);
+
+		// entrypoint: "reinfcore-gametest"
+		ReinforcedCoreMod.initializeReinforcedCoreGameTest();
+	}
+
+	private static void initializeReinforcedCoreGameTest() {
+		List<EntrypointContainer<Object>> entrypointContainers = FabricLoader.getInstance()
+				.getEntrypointContainers(String.format("%s-gametest", MOD_ID), Object.class);
+
+		for (EntrypointContainer<Object> container : entrypointContainers) {
+			Class<?> testClass = container.getEntrypoint().getClass();
+			String modid = container.getProvider().getMetadata().getId();
+
+			if (GAME_TEST_IDS.containsKey(testClass)) {
+				throw new UnsupportedOperationException("Test class (%s) has already been registered with mod (%s)"
+						.formatted(testClass.getCanonicalName(), modid));
+			}
+
+			GAME_TEST_IDS.put(testClass, modid);
+			TestFunctions.register(testClass);
+
+			LOGGER.debug("Registered test class {} for mod {}", testClass.getCanonicalName(), modid);
+		}
 	}
 }


### PR DESCRIPTION
- renamed entrypoint `reinfcoreclient` to `reinfcore-client`
- added entrypoint `reinfcore-gametest`
